### PR TITLE
Introduce FromJSONBetterErrors class to simplify interface

### DIFF
--- a/src/Data/Aeson/BetterErrors.hs
+++ b/src/Data/Aeson/BetterErrors.hs
@@ -20,15 +20,9 @@ module Data.Aeson.BetterErrors
   , (.!)
 
   -- * Basic parsers
-  , asText
-  , asString
-  , asScientific
+  , FromJSONBetterErrors(..)
   , asIntegral
   , asRealFloat
-  , asBool
-  , asNull
-  , asObject
-  , asArray
 
   -- * Traversing JSON
   , perhaps
@@ -47,25 +41,15 @@ module Data.Aeson.BetterErrors
   , eachInObjectWithKey
 
   -- * Custom validations
-  , withText
-  , withString
-  , withScientific
+  , with
   , withIntegral
   , withRealFloat
-  , withBool
-  , withObject
-  , withArray
   , throwCustomError
 
   -- ** Monadic validators
-  , withTextM
-  , withStringM
-  , withScientificM
+  , withM
   , withIntegralM
   , withRealFloatM
-  , withBoolM
-  , withObjectM
-  , withArrayM
 
   -- * Running parsers
   , parse


### PR DESCRIPTION
What do you think of this?  It gets rid of many of the `as*` and `with*` functions in favor of a class.  It also lets the user define their own instances of this class (as I found myself wanting to do when writing new parsers).  The class name and `value` function could certainly have some other names, but this is the best I could think of.  The old functions could also be kept around for backwards compatibility.

I hope you don't mind my suggesting all these changes.  I've found this really useful for my needs and have a better understanding of what makes it so having actually used it now (https://github.com/databrary/databrary/blob/ingest/Databrary/Ingest/JSON.hs if you're curious).