### PR TITLE
Import forM from Control.Monad instead of Control.Monad.Reader

### DIFF
--- a/src/Data/Aeson/BetterErrors/Internal.hs
+++ b/src/Data/Aeson/BetterErrors/Internal.hs
@@ -12,6 +12,7 @@ import Data.Foldable (foldMap)
 #endif
 
 import Control.Arrow (left)
+import Control.Monad
 import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.Trans.Except


### PR DESCRIPTION
There is an intention to stop re-exporting functions from `base` in future versions of `mtl`: https://github.com/haskell/mtl/pull/74
This PR brings `aeson-better-errors` in line with the proposed change, because at the moment `Data.Aeson.BetterErrors.Internal` exports `forM` (originally from `Control.Monad`) from `Control.Monad.Reader`.