### PR TITLE
Make compatible with aeson >2.0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Revision history for aeson-better-errors
+
+## 0.9.1.1
+
+* Make compatible with aeson >2.0.0.0
+
+
+## Previous versions
+
+* Please see git history

--- a/aeson-better-errors.cabal
+++ b/aeson-better-errors.cabal
@@ -26,7 +26,7 @@ library
                      Data.Aeson.BetterErrors.Internal
   other-modules:     Data.Aeson.BetterErrors.Utils
   build-depends:     base >=4.5 && <5
-                   , aeson >=0.7
+                   , aeson >=0.7 && <1.6 || >=2.0 && <2.1
                    , unordered-containers
                    , dlist
                    , text

--- a/aeson-better-errors.cabal
+++ b/aeson-better-errors.cabal
@@ -1,5 +1,5 @@
 name:                aeson-better-errors
-version:             0.9.1.0
+version:             0.9.1.1
 synopsis:            Better error messages when decoding JSON values.
 license:             MIT
 license-file:        LICENSE
@@ -10,6 +10,7 @@ category:            Text, Web, JSON
 build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  README.md
+                   , CHANGELOG.md
 
 description:
   A small package which gives you the tools to build parsers to decode JSON


### PR DESCRIPTION
Fixes https://github.com/hdgarrood/aeson-better-errors/issues/17

They changed their internal representation of object keys in a
breaking way.

I opted to leave the API as is, that is still take normale `Text` as
keys and convert to their `Key` type at the last possible moment. This
means this library does not have a breaking change.

I compiled it manually, once with 1.5.6.0 and once with 2.0.3.0.