### PR TITLE
bump `aeson` upper bound, bump Stack resolver

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -1,0 +1,72 @@
+# https://github.com/haskell/actions/tree/main/setup#model-cabal-workflow-with-caching
+name: build
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ghc-version: ['9.6', '9.4']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up GHC ${{ matrix.ghc-version }}
+        uses: haskell/actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.ghc-version }}
+          # Defaults, added for clarity:
+          cabal-version: 'latest'
+          cabal-update: true
+
+      - name: Configure the build
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v3
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Install dependencies
+        run: cabal build all --only-dependencies
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v3
+        # Caches are immutable, trying to save with the same key would error.
+        if: ${{ steps.cache.outputs.cache-primary-key != steps.cache.outputs.cache-matched-key }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Build
+        run: cabal build all
+
+      - name: Run tests
+        run: cabal test all
+
+      - name: Check cabal file
+        run: cabal check
+
+      - name: Build documentation
+        run: cabal haddock all

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist
 .stack-work/
+
+dist-newstyle

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # aeson-better-errors
 
+[![Build status](https://github.com/hdgarrood/aeson-better-errors/actions/workflows/cabal.yml/badge.svg)](https://github.com/hdgarrood/aeson-better-errors/actions/workflows/cabal.yml)
+
 A small package which gives you tools to build parsers to decode JSON values,
 and gives good error messages when parsing fails.
 

--- a/aeson-better-errors.cabal
+++ b/aeson-better-errors.cabal
@@ -27,7 +27,7 @@ library
                      Data.Aeson.BetterErrors.Internal
   other-modules:     Data.Aeson.BetterErrors.Utils
   build-depends:     base >=4.5 && <5
-                   , aeson >=0.7 && <1.6 || >=2.0 && <2.1
+                   , aeson >=0.7 && <1.6 || >=2.0 && <2.3
                    , unordered-containers
                    , dlist
                    , text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.26
+resolver: lts-21.11
 packages:
 - '.'
 extra-deps: []


### PR DESCRIPTION
and basic GitHub Action copied from https://github.com/haskell/actions/tree/main/setup#model-cabal-workflow-with-caching

```
cabal build all --constraint 'aeson == 2.2.0.0' --enable-tests
```
succeeds

`stack build` succeeds