### PR TITLE
Support mtl-2.3

### DIFF
--- a/src/Data/Aeson/BetterErrors/Internal.hs
+++ b/src/Data/Aeson/BetterErrors/Internal.hs
@@ -10,6 +10,10 @@ module Data.Aeson.BetterErrors.Internal where
 import Control.Applicative (Applicative, pure, (<$>), (<*>))
 import Data.Foldable (foldMap)
 #endif
+#if MIN_VERSION_mtl(2, 3, 0)
+import Control.Monad (forM)
+#else
+#endif
 
 import Control.Arrow (left)
 import Control.Monad.Identity


### PR DESCRIPTION
mtl 2.3 doesn't export various Control.Monad functions. Explicitly import forM.

Fix adapted from https://github.com/stevenfontanella/microlens/commit/ea077dace719fe4ab5a82e45c1986c901a61cd1d